### PR TITLE
Add the ability to set validation exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The Source Param Middleware can be configured with a variety of options, passed 
   - `cmdbApiKey`: The [CMDB] API key used to validate the source parameter.
   - `errorMessage`: The error message to output if the source parameter is not present and valid. Defaults to `"The source parameter is required and should be a valid system code"`
   - `pollInterval`: How often to check for new system codes on [CMDB] in milliseconds. Defaults to 60000 (1 minute)
+  - `validationExceptions`: An array of source parameter values which should always pass validation, bypassing CMDB checks. These values are still required to be between 1 and 255 characters in length. Defaults to `["test"]`
   - `verifyUsingCmdb`: Whether to verify that the source parameter is a valid system code using [CMDB]. Defaults to `true`
 
 

--- a/lib/source-param-middleware.js
+++ b/lib/source-param-middleware.js
@@ -11,6 +11,9 @@ module.exports.defaults = {
 	errorMessage: 'The source parameter is required and must be a valid system code',
 	log: console,
 	pollInterval: 300000, // 5 minutes
+	validationExceptions: [
+		'test'
+	],
 	verifyUsingCmdb: true
 };
 
@@ -33,7 +36,7 @@ function sourceParam(options) {
 		// to hook into the promise
 		return fetchSystemCodes(options.cmdbApiKey)
 			.then(codes => {
-				validSystemCodes = codes;
+				validSystemCodes = codes.concat(options.validationExceptions);
 			})
 			.catch(error => {
 				// If the poll errors then we don't throw,
@@ -46,20 +49,25 @@ function sourceParam(options) {
 
 	// The generated middleware function
 	function middleware(request, response, next) {
+		const source = request.query.source;
+
 		// Check for a valid system code format
-		if (!isValidSystemCodeFormat(request.query.source)) {
+		if (!isValidSystemCodeFormat(source)) {
 			return next(httpError(400, options.errorMessage));
 		}
+
 		// If we have a copy of the system codes array,
 		// check the source parameter against it
-		if (validSystemCodes && !validSystemCodes.includes(request.query.source)) {
+		if (validSystemCodes && !validSystemCodes.includes(source)) {
 			return next(httpError(400, options.errorMessage));
 		}
+
 		// If we don't have system codes from CMDB, but
 		// are supposed to validate against them...
 		if (options.verifyUsingCmdb && !validSystemCodes) {
-			options.log.warn(`CMDB warning: The system code "${request.query.source}" cannot be verified due to a CMDB failure`);
+			options.log.warn(`CMDB warning: The system code "${source}" cannot be verified due to a CMDB failure`);
 		}
+
 		return next();
 	}
 


### PR DESCRIPTION
This allows individual applications to bypass CMDB validation for
certain source parameters, e.g. for testing purposes.