### PR TITLE
Use the X-Api-Key header rather than a query param

### DIFF
--- a/lib/fetch-system-codes.js
+++ b/lib/fetch-system-codes.js
@@ -8,11 +8,11 @@ module.exports = fetchSystemCodes;
 
 // Fetch all system codes from the CMDB API
 function fetchSystemCodes(apiKey, page = 1, systemCodes = []) {
-	const url = buildApiUrl(apiKey, page);
+	const url = buildApiUrl(page);
 	let totalPages;
 
 	// Get a page of system code JSON
-	return getJson(url)
+	return getJson(url, apiKey)
 		.then(response => {
 			// Grab the total number of pages of system codes
 			totalPages = getPagesFromCountHeader(response.headers.count);
@@ -34,8 +34,8 @@ function fetchSystemCodes(apiKey, page = 1, systemCodes = []) {
 }
 
 // Build an API URL with a provided API key and page
-function buildApiUrl(apiKey, page) {
-	return `https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&apikey=${apiKey}&page=${page}`;
+function buildApiUrl(page) {
+	return `https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&page=${page}`;
 }
 
 // Parse the Count header to get the total number of
@@ -49,11 +49,12 @@ function getPagesFromCountHeader(countHeader) {
 }
 
 // Fetch JSON from an URL using a GET request
-function getJson(url) {
+function getJson(url, apiKey) {
 	return new Promise((resolve, reject) => {
 		request({
 			headers: {
-				'User-Agent': `${pkg.name}@${pkg.version} (${pkg.homepage})`
+				'User-Agent': `${pkg.name}@${pkg.version} (${pkg.homepage})`,
+				'X-Api-Key': apiKey
 			},
 			json: true,
 			url

--- a/test/unit/lib/fetch-system-codes.js
+++ b/test/unit/lib/fetch-system-codes.js
@@ -20,7 +20,8 @@ describe('lib/middleware/fetch-system-codes', () => {
 
 		userAgent = `${pkg.name}@${pkg.version} (${pkg.homepage})`;
 		expectedHeaders = {
-			'User-Agent': userAgent
+			'User-Agent': userAgent,
+			'X-Api-Key': 'mock-api-key'
 		};
 
 		fetchSystemCodes = require('../../../lib/fetch-system-codes');
@@ -85,17 +86,17 @@ describe('lib/middleware/fetch-system-codes', () => {
 			assert.calledWith(request.getCall(0), {
 				headers: expectedHeaders,
 				json: true,
-				url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&apikey=mock-api-key&page=1'
+				url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&page=1'
 			});
 			assert.calledWith(request.getCall(1), {
 				headers: expectedHeaders,
 				json: true,
-				url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&apikey=mock-api-key&page=2'
+				url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&page=2'
 			});
 			assert.calledWith(request.getCall(2), {
 				headers: expectedHeaders,
 				json: true,
-				url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&apikey=mock-api-key&page=3'
+				url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&page=3'
 			});
 		});
 
@@ -124,7 +125,7 @@ describe('lib/middleware/fetch-system-codes', () => {
 				assert.calledWith(request.getCall(0), {
 					headers: expectedHeaders,
 					json: true,
-					url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&apikey=mock-api-key&page=1'
+					url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&page=1'
 				});
 			});
 
@@ -153,7 +154,7 @@ describe('lib/middleware/fetch-system-codes', () => {
 				assert.calledWith(request.getCall(0), {
 					headers: expectedHeaders,
 					json: true,
-					url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&apikey=mock-api-key&page=1'
+					url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&page=1'
 				});
 			});
 


### PR DESCRIPTION
This work prepares us for a move to CMDB v3, which no longer accepts the
query parameter. We'll update to use v3 URLs once it's live.