### PR TITLE
Use the CMDB v3 /items/system endpoint

### DIFF
--- a/lib/fetch-system-codes.js
+++ b/lib/fetch-system-codes.js
@@ -18,8 +18,8 @@ function fetchSystemCodes(apiKey, page = 1, systemCodes = []) {
 			totalPages = getPagesFromCountHeader(response.headers.count);
 			// We're only interested in system codes
 			return response.body
-				.filter(entry => entry.systemCode)
-				.map(entry => entry.systemCode);
+				.filter(entry => entry.dataItemID)
+				.map(entry => entry.dataItemID);
 		})
 		.then(newCodes => {
 			// Add the new system codes to our in-progress full list

--- a/lib/fetch-system-codes.js
+++ b/lib/fetch-system-codes.js
@@ -16,8 +16,10 @@ function fetchSystemCodes(apiKey, page = 1, systemCodes = []) {
 		.then(response => {
 			// Grab the total number of pages of system codes
 			totalPages = getPagesFromCountHeader(response.headers.count);
-			// We're only interested in system code values
-			return response.body.map(entry => entry.value);
+			// We're only interested in system codes
+			return response.body
+				.filter(entry => entry.systemCode)
+				.map(entry => entry.systemCode);
 		})
 		.then(newCodes => {
 			// Add the new system codes to our in-progress full list
@@ -35,7 +37,11 @@ function fetchSystemCodes(apiKey, page = 1, systemCodes = []) {
 
 // Build an API URL with a provided API key and page
 function buildApiUrl(page) {
-	return `https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&page=${page}`;
+	// After some experimentation, this is the number of results
+	// we can safely request per page with no risk of gateway
+	// timeouts or other issues
+	const perPageLimit = 250;
+	return `https://cmdb.in.ft.com/v3/items/system?page=${page}&limit=${perPageLimit}`;
 }
 
 // Parse the Count header to get the total number of

--- a/test/unit/lib/fetch-system-codes.js
+++ b/test/unit/lib/fetch-system-codes.js
@@ -46,9 +46,9 @@ describe('lib/middleware/fetch-system-codes', () => {
 					count: 'Pages: 3, Items: 4'
 				},
 				body: [
-					{systemCode: 'foo'},
-					{noSystemCode: 'this should not appear'},
-					{systemCode: 'bar'}
+					{dataItemID: 'foo'},
+					{noDataItemID: 'this should not appear'},
+					{dataItemID: 'bar'}
 				]
 			};
 			mockResponse2 = {
@@ -57,8 +57,8 @@ describe('lib/middleware/fetch-system-codes', () => {
 					count: 'Pages: 3, Items: 4'
 				},
 				body: [
-					{noSystemCode: 'this should not appear'},
-					{systemCode: 'baz'}
+					{noDataItemID: 'this should not appear'},
+					{dataItemID: 'baz'}
 				]
 			};
 			mockResponse3 = {
@@ -67,7 +67,7 @@ describe('lib/middleware/fetch-system-codes', () => {
 					count: 'Pages: 3, Items: 4'
 				},
 				body: [
-					{systemCode: 'qux'}
+					{dataItemID: 'qux'}
 				]
 			};
 			request.onCall(0).yields(null, mockResponse1);

--- a/test/unit/lib/fetch-system-codes.js
+++ b/test/unit/lib/fetch-system-codes.js
@@ -46,8 +46,9 @@ describe('lib/middleware/fetch-system-codes', () => {
 					count: 'Pages: 3, Items: 4'
 				},
 				body: [
-					{value: 'foo'},
-					{value: 'bar'}
+					{systemCode: 'foo'},
+					{noSystemCode: 'this should not appear'},
+					{systemCode: 'bar'}
 				]
 			};
 			mockResponse2 = {
@@ -56,7 +57,8 @@ describe('lib/middleware/fetch-system-codes', () => {
 					count: 'Pages: 3, Items: 4'
 				},
 				body: [
-					{value: 'baz'}
+					{noSystemCode: 'this should not appear'},
+					{systemCode: 'baz'}
 				]
 			};
 			mockResponse3 = {
@@ -65,7 +67,7 @@ describe('lib/middleware/fetch-system-codes', () => {
 					count: 'Pages: 3, Items: 4'
 				},
 				body: [
-					{value: 'qux'}
+					{systemCode: 'qux'}
 				]
 			};
 			request.onCall(0).yields(null, mockResponse1);
@@ -86,17 +88,17 @@ describe('lib/middleware/fetch-system-codes', () => {
 			assert.calledWith(request.getCall(0), {
 				headers: expectedHeaders,
 				json: true,
-				url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&page=1'
+				url: 'https://cmdb.in.ft.com/v3/items/system?page=1&limit=250'
 			});
 			assert.calledWith(request.getCall(1), {
 				headers: expectedHeaders,
 				json: true,
-				url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&page=2'
+				url: 'https://cmdb.in.ft.com/v3/items/system?page=2&limit=250'
 			});
 			assert.calledWith(request.getCall(2), {
 				headers: expectedHeaders,
 				json: true,
-				url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&page=3'
+				url: 'https://cmdb.in.ft.com/v3/items/system?page=3&limit=250'
 			});
 		});
 
@@ -125,7 +127,7 @@ describe('lib/middleware/fetch-system-codes', () => {
 				assert.calledWith(request.getCall(0), {
 					headers: expectedHeaders,
 					json: true,
-					url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&page=1'
+					url: 'https://cmdb.in.ft.com/v3/items/system?page=1&limit=250'
 				});
 			});
 
@@ -154,7 +156,7 @@ describe('lib/middleware/fetch-system-codes', () => {
 				assert.calledWith(request.getCall(0), {
 					headers: expectedHeaders,
 					json: true,
-					url: 'https://cmdb.ft.com/v2/itemattributes/?attributeType=systemCode&page=1'
+					url: 'https://cmdb.in.ft.com/v3/items/system?page=1&limit=250'
 				});
 			});
 


### PR DESCRIPTION
We've had to switch endpoints for the move from v2 to v3 of CMDB. The intention is to support filtering in the URL at a later date which may mean we can increase the per-page limit and only request the data we need.